### PR TITLE
(WIP)Fix: implement working contact form using Resend

### DIFF
--- a/app/actions/contact-form.ts
+++ b/app/actions/contact-form.ts
@@ -153,8 +153,8 @@ export async function submitContactForm(
     const resend = new Resend(process.env.RESEND_API_KEY!);
 
     await resend.emails.send({
-      from: process.env.CONTACT_FROM_EMAIL,
-      to: process.env.CONTACT_TO_EMAIL,
+      from: process.env.CONTACT_FROM_EMAIL!,
+      to: process.env.CONTACT_TO_EMAIL!,
       reply_to: validatedData.email,
       subject: `[Contact] ${validatedData.subject}`,
       text: `From: ${validatedData.name} <${validatedData.email}>\n\n${validatedData.message}`,

--- a/app/actions/contact-form.ts
+++ b/app/actions/contact-form.ts
@@ -149,20 +149,17 @@ export async function submitContactForm(
     // Simulate server processing delay
     await new Promise((resolve) => setTimeout(resolve, 1000))
 
-    // In a real application, you would send an email, store in a database, etc.
-    // For now, we'll just simulate a successful submission
-    const resend = new Resend(process.env.RESEND_API_KEY!)
-    console.log("FROM FIELD:", {
-      from: "onboarding@resend.dev",
-      to: "yusukeko@usc.edu",
-    })
+   // In a real application, you would send an email, store in a database, etc.
+    const resend = new Resend(process.env.RESEND_API_KEY!);
+
     await resend.emails.send({
-      from: "onboarding@resend.dev", 
-      to: "yusukeko@usc.edu", 
+      from: process.env.CONTACT_FROM_EMAIL,
+      to: process.env.CONTACT_TO_EMAIL,
       reply_to: validatedData.email,
       subject: `[Contact] ${validatedData.subject}`,
       text: `From: ${validatedData.name} <${validatedData.email}>\n\n${validatedData.message}`,
-    })
+    });
+
 
     // Uncomment to simulate a random server error for testing
     // if (Math.random() > 0.7) {

--- a/app/actions/contact-form.ts
+++ b/app/actions/contact-form.ts
@@ -3,6 +3,7 @@
 import { z } from "zod"
 import { cookies } from "next/headers"
 import { revalidatePath } from "next/cache"
+import { Resend } from "resend"
 
 // Define the form schema using Zod for validation
 const contactFormSchema = z.object({
@@ -150,6 +151,18 @@ export async function submitContactForm(
 
     // In a real application, you would send an email, store in a database, etc.
     // For now, we'll just simulate a successful submission
+    const resend = new Resend(process.env.RESEND_API_KEY!)
+    console.log("FROM FIELD:", {
+      from: "onboarding@resend.dev",
+      to: "yusukeko@usc.edu",
+    })
+    await resend.emails.send({
+      from: "onboarding@resend.dev", 
+      to: "yusukeko@usc.edu", 
+      reply_to: validatedData.email,
+      subject: `[Contact] ${validatedData.subject}`,
+      text: `From: ${validatedData.name} <${validatedData.email}>\n\n${validatedData.message}`,
+    })
 
     // Uncomment to simulate a random server error for testing
     // if (Math.random() > 0.7) {

--- a/app/actions/contact-form.ts
+++ b/app/actions/contact-form.ts
@@ -155,7 +155,7 @@ export async function submitContactForm(
     await resend.emails.send({
       from: process.env.CONTACT_FROM_EMAIL,
       to: process.env.CONTACT_TO_EMAIL,
-      reply_to: validatedData.email,
+      replyTo: validatedData.email,
       subject: `[Contact] ${validatedData.subject}`,
       text: `From: ${validatedData.name} <${validatedData.email}>\n\n${validatedData.message}`,
     });

--- a/app/actions/contact-form.ts
+++ b/app/actions/contact-form.ts
@@ -153,8 +153,8 @@ export async function submitContactForm(
     const resend = new Resend(process.env.RESEND_API_KEY!);
 
     await resend.emails.send({
-      from: process.env.CONTACT_FROM_EMAIL,
-      to: process.env.CONTACT_TO_EMAIL,
+      from: process.env.CONTACT_FROM_EMAIL!,
+      to: process.env.CONTACT_TO_EMAIL!,
       replyTo: validatedData.email,
       subject: `[Contact] ${validatedData.subject}`,
       text: `From: ${validatedData.name} <${validatedData.email}>\n\n${validatedData.message}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "react-day-picker": "^8.10.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.50.0",
+        "resend": "^6.0.3",
         "sonner": "^1.4.0",
         "tailwind-merge": "^2.2.1",
         "tailwindcss-animate": "^1.0.7",
@@ -7376,6 +7377,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.0.3.tgz",
+      "integrity": "sha512-Yb7o2n52v91LjkUjq5vIZQbJrGiaPoMo2VPAyS0QTKA73tmvHMUQ7P1M56J1ux/Cw9Lf68PeaKidTl6GuS8DTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@react-email/render": "^1.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-day-picker": "^8.10.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.50.0",
+    "resend": "^6.0.3",
     "sonner": "^1.4.0",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7",
@@ -73,4 +74,3 @@
     "typescript": "^5.3.3"
   }
 }
-


### PR DESCRIPTION
## What was done
 - Updated app/actions/contact-form.ts:
 - Added Resend client and await resend.emails.send(...) call
 - Hardcoded from: onboarding@resend.dev
 - Temporarily set to: yusukeko@usc.edu (my account email) for sandbox testing
 - Left all existing validation, CSRF token, and honeypot logic intact
## Current state
 - Form submissions successfully send email in sandbox (confirmed delivery to my USC email)
 - External recipients (e.g. Gmail) are still blocked because pal-ate.com domain is not verified
## Next steps
 - Verify pal-ate.com domain in Resend (add TXT/CNAME DNS records)
 - Switch from to no-reply@pal-ate.com and update to to the official contact address (e.g. info@pal-ate.com)
 - Remove hardcoded sandbox values and manage via .env